### PR TITLE
Fix check whether we're running in Emacs

### DIFF
--- a/chicken-doc-cmd.scm
+++ b/chicken-doc-cmd.scm
@@ -72,7 +72,7 @@
     ((unix) "less")
     (else "")))
 (define (with-output-to-pager thunk)
-  (cond ((get-environment-variable "EMACS")
+  (cond ((get-environment-variable "INSIDE_EMACS")
          (thunk))  ; Don't page in emacs subprocess.
         ((not (terminal-port? (current-output-port)))
          (thunk))  ; Don't page if stdout is not a TTY.


### PR DESCRIPTION
Emacs does no longer set `EMACS`.  To quote another Emacs package:

```
      ;; The "INFERIOR=yes" hack is for SWI-Prolog 7.2.3 and earlier,
      ;; which assumes it is running under Emacs if either INFERIOR=yes or
      ;; if EMACS is set to a nonempty value.  The EMACS setting is
      ;; obsolescent, so set INFERIOR.  Newer versions of SWI-Prolog should
      ;; know about INSIDE_EMACS (which replaced EMACS) and should not need
      ;; this hack.
```

For this reason I've changed the code to check for `INSIDE_EMACS` instead. You can test this change by running `chicken-doc -i scheme` in `M-x shell`.